### PR TITLE
kafka: add tests for storage and verify mounted cm

### DIFF
--- a/tests/suites/kafka_brokers/kafka_broker_test.go
+++ b/tests/suites/kafka_brokers/kafka_broker_test.go
@@ -86,12 +86,14 @@ var _ = Describe("KafkaTest", func() {
 
 var _ = BeforeSuite(func() {
 	utils.TearDown(TestNamespace)
+	Expect(utils.DeletePVCs("data-dir")).To(BeNil())
 	utils.KClient.CreateNamespace(TestNamespace, false)
 	utils.Setup(TestNamespace)
 })
 
 var _ = AfterSuite(func() {
 	utils.TearDown(TestNamespace)
+	Expect(utils.DeletePVCs("data-dir")).To(BeNil())
 })
 
 func TestService(t *testing.T) {

--- a/tests/suites/kafka_install/kafka_install_test.go
+++ b/tests/suites/kafka_install/kafka_install_test.go
@@ -42,12 +42,14 @@ var _ = Describe("KafkaInstallTest", func() {
 
 var _ = BeforeSuite(func() {
 	utils.TearDown(customNamespace)
+	Expect(utils.DeletePVCs("data-dir")).To(BeNil())
 	utils.KClient.CreateNamespace(customNamespace, false)
 	utils.Setup(customNamespace)
 })
 
 var _ = AfterSuite(func() {
 	utils.TearDown(customNamespace)
+	Expect(utils.DeletePVCs("data-dir")).To(BeNil())
 	utils.KClient.DeleteNamespace(customNamespace)
 })
 

--- a/tests/suites/kafka_kerberos/kafka_kerberos_test.go
+++ b/tests/suites/kafka_kerberos/kafka_kerberos_test.go
@@ -59,6 +59,7 @@ var _ = Describe("KafkaTest", func() {
 
 var _ = BeforeSuite(func() {
 	utils.TearDown(customNamespace)
+	Expect(utils.DeletePVCs("data-dir")).To(BeNil())
 	utils.KClient.CreateNamespace(customNamespace, false)
 	Expect(krb5Client.Deploy()).To(BeNil())
 	utils.SetupWithKerberos(customNamespace)
@@ -67,6 +68,7 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	utils.TearDown(customNamespace)
 	Expect(krb5Client.TearDown()).To(BeNil())
+	Expect(utils.DeletePVCs("data-dir")).To(BeNil())
 	utils.KClient.DeleteNamespace(customNamespace)
 })
 

--- a/tests/suites/kafka_storage/kafka_storage_test.go
+++ b/tests/suites/kafka_storage/kafka_storage_test.go
@@ -1,0 +1,82 @@
+package kafka_storage
+
+import (
+	"fmt"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/mesosphere/kudo-kafka-operator/tests/suites"
+
+	"github.com/mesosphere/kudo-kafka-operator/tests/utils"
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/reporters"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	customNamespace = "kafka-storage-test"
+)
+
+var _ = Describe("KafkaStorage", func() {
+	Describe("[Kafka Storage]", func() {
+		Context("storage options", func() {
+			kafkaClient := utils.NewKafkaClient(utils.KClient, &utils.KafkaClientConfiguration{
+				Namespace: utils.String(customNamespace),
+			})
+			It("verify that access mode is ReadWriteOnce", func() {
+				err := utils.KClient.WaitForStatefulSetReadyReplicasCount(suites.DefaultKafkaStatefulSetName, customNamespace, 3, 300)
+				Expect(err).To(BeNil())
+				sts, err := utils.KClient.AppsV1().StatefulSets(customNamespace).Get(suites.DefaultKafkaStatefulSetName, metav1.GetOptions{})
+				Expect(err).To(BeNil())
+				Expect(len(sts.Spec.VolumeClaimTemplates)).To(BeNumerically("==", 1))
+				for _, pvc := range sts.Spec.VolumeClaimTemplates {
+					for _, accessMode := range pvc.Spec.AccessModes {
+						Expect(accessMode).To(Equal(v1.ReadWriteOnce))
+					}
+				}
+			})
+			It("verify all configmaps are mounted", func() {
+				output, err := kafkaClient.ExecInPod(customNamespace, "kafka-kafka-0", suites.DefaultContainerName,
+					[]string{"findmnt", "/bootstrap"})
+				Expect(err).To(BeNil())
+				Expect(output).To(ContainSubstring("kubernetes.io~configmap/bootstrap"))
+				output, err = kafkaClient.ExecInPod(customNamespace, "kafka-kafka-0", suites.DefaultContainerName,
+					[]string{"findmnt", "/metrics"})
+				Expect(err).To(BeNil())
+				Expect(output).To(ContainSubstring("kubernetes.io~configmap/metrics"))
+				output, err = kafkaClient.ExecInPod(customNamespace, "kafka-kafka-0", suites.DefaultContainerName,
+					[]string{"findmnt", "/health-check-script"})
+				Expect(err).To(BeNil())
+				Expect(output).To(ContainSubstring("kubernetes.io~configmap/health-check-script"))
+				output, err = kafkaClient.ExecInPod(customNamespace, "kafka-kafka-0", suites.DefaultContainerName,
+					[]string{"findmnt", "/config"})
+				Expect(err).To(BeNil())
+				Expect(output).To(ContainSubstring("kubernetes.io~configmap/config"))
+				output, err = kafkaClient.ExecInPod(customNamespace, "kafka-kafka-0", suites.DefaultContainerName,
+					[]string{"findmnt", "/var/lib/kafka"})
+				Expect(err).To(BeNil())
+				Expect(output).To(ContainSubstring("/var/lib/kafka"))
+			})
+
+		})
+	})
+})
+
+var _ = BeforeSuite(func() {
+	utils.TearDown(customNamespace)
+	utils.KClient.CreateNamespace(customNamespace, false)
+	utils.Setup(customNamespace)
+})
+
+var _ = AfterSuite(func() {
+	utils.TearDown(customNamespace)
+	utils.KClient.DeleteNamespace(customNamespace)
+})
+
+func TestService(t *testing.T) {
+	RegisterFailHandler(Fail)
+	junitReporter := reporters.NewJUnitReporter(fmt.Sprintf("%s-junit.xml", "kafka-storage"))
+	RunSpecsWithDefaultAndCustomReporters(t, "KafkaStorage Suite", []Reporter{junitReporter})
+}

--- a/tests/suites/kafka_storage/kafka_storage_test.go
+++ b/tests/suites/kafka_storage/kafka_storage_test.go
@@ -66,12 +66,14 @@ var _ = Describe("KafkaStorage", func() {
 
 var _ = BeforeSuite(func() {
 	utils.TearDown(customNamespace)
+	Expect(utils.DeletePVCs("data-dir")).To(BeNil())
 	utils.KClient.CreateNamespace(customNamespace, false)
 	utils.Setup(customNamespace)
 })
 
 var _ = AfterSuite(func() {
 	utils.TearDown(customNamespace)
+	Expect(utils.DeletePVCs("data-dir")).To(BeNil())
 	utils.KClient.DeleteNamespace(customNamespace)
 })
 

--- a/tests/suites/kafka_topics/kafka_topic_test.go
+++ b/tests/suites/kafka_topics/kafka_topic_test.go
@@ -63,12 +63,14 @@ var _ = Describe("KafkaTest", func() {
 
 var _ = BeforeSuite(func() {
 	utils.TearDown(customNamespace)
+	Expect(utils.DeletePVCs("data-dir")).To(BeNil())
 	utils.KClient.CreateNamespace(customNamespace, false)
 	utils.Setup(customNamespace)
 })
 
 var _ = AfterSuite(func() {
 	utils.TearDown(customNamespace)
+	Expect(utils.DeletePVCs("data-dir")).To(BeNil())
 })
 
 func TestService(t *testing.T) {

--- a/tests/suites/kafka_topics/kafka_topic_test.go
+++ b/tests/suites/kafka_topics/kafka_topic_test.go
@@ -12,27 +12,30 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var topicName string
+var (
+	topicName       string
+	customNamespace = "kafka-sanity-test"
+)
 
 var _ = Describe("KafkaTest", func() {
 	Describe("[Kafka Sanity Checks]", func() {
 		Context("Default installation", func() {
 			It("statefulset should have 3 replicas with status READY", func() {
-				err := utils.KClient.WaitForStatefulSetReadyReplicasCount(DefaultZkStatefulSetName, TestNamespace, 3, 240)
+				err := utils.KClient.WaitForStatefulSetReadyReplicasCount(DefaultZkStatefulSetName, customNamespace, 3, 240)
 				Expect(err).To(BeNil())
-				err = utils.KClient.WaitForStatefulSetReadyReplicasCount(DefaultKafkaStatefulSetName, TestNamespace, 3, 240)
+				err = utils.KClient.WaitForStatefulSetReadyReplicasCount(DefaultKafkaStatefulSetName, customNamespace, 3, 240)
 				Expect(err).To(BeNil())
-				Expect(utils.KClient.GetStatefulSetCount(DefaultKafkaStatefulSetName, TestNamespace)).To(Equal(3))
+				Expect(utils.KClient.GetStatefulSetCount(DefaultKafkaStatefulSetName, customNamespace)).To(Equal(3))
 			})
 			It("write in broker-3 a message with replication 3 and scale down to 3 brokers and read message from another broker", func() {
 				kafkaClient := utils.NewKafkaClient(utils.KClient, &utils.KafkaClientConfiguration{
-					Namespace: utils.String(TestNamespace),
+					Namespace: utils.String(customNamespace),
 				})
 				topicSuffix, _ := utils.GetRandString(6)
 				topicName := fmt.Sprintf("test-topic-%s", topicSuffix)
-				err := utils.KClient.UpdateInstancesCount(DefaultKudoKafkaInstance, TestNamespace, 4)
+				err := utils.KClient.UpdateInstancesCount(DefaultKudoKafkaInstance, customNamespace, 4)
 				Expect(err).To(BeNil())
-				err = utils.KClient.WaitForStatefulSetReadyReplicasCount(DefaultKafkaStatefulSetName, TestNamespace, 4, 240)
+				err = utils.KClient.WaitForStatefulSetReadyReplicasCount(DefaultKafkaStatefulSetName, customNamespace, 4, 240)
 				Expect(err).To(BeNil())
 				out, err := kafkaClient.CreateTopic(GetBrokerPodName(3), DefaultContainerName, topicName, "0:1:3")
 				Expect(err).To(BeNil())
@@ -43,9 +46,9 @@ var _ = Describe("KafkaTest", func() {
 				out, err = kafkaClient.ReadFromTopic(GetBrokerPodName(3), DefaultContainerName, topicName, messageToTest)
 				Expect(err).To(BeNil())
 				Expect(out).To(ContainSubstring(messageToTest))
-				err = utils.KClient.UpdateInstancesCount(DefaultKudoKafkaInstance, TestNamespace, 3)
+				err = utils.KClient.UpdateInstancesCount(DefaultKudoKafkaInstance, customNamespace, 3)
 				Expect(err).To(BeNil())
-				err = utils.KClient.WaitForStatefulSetReadyReplicasCount(DefaultKafkaStatefulSetName, TestNamespace, 3, 240)
+				err = utils.KClient.WaitForStatefulSetReadyReplicasCount(DefaultKafkaStatefulSetName, customNamespace, 3, 240)
 				// in case the broker with id 3 was the active controller we should wait for the new active controller
 				kafkaClient.WaitForBrokersToBeRegisteredWithService(GetBrokerPodName(0), DefaultContainerName, 100)
 				kafkaClient.WaitForBrokersToBeRegisteredWithService(GetBrokerPodName(1), DefaultContainerName, 100)
@@ -59,13 +62,13 @@ var _ = Describe("KafkaTest", func() {
 })
 
 var _ = BeforeSuite(func() {
-	utils.TearDown(TestNamespace)
-	utils.KClient.CreateNamespace(TestNamespace, false)
-	utils.Setup(TestNamespace)
+	utils.TearDown(customNamespace)
+	utils.KClient.CreateNamespace(customNamespace, false)
+	utils.Setup(customNamespace)
 })
 
 var _ = AfterSuite(func() {
-	utils.TearDown(TestNamespace)
+	utils.TearDown(customNamespace)
 })
 
 func TestService(t *testing.T) {

--- a/tests/utils/client.go
+++ b/tests/utils/client.go
@@ -284,6 +284,22 @@ func Retry(attempts int, sleep time.Duration, condition string, f func() (string
 	return resp, fmt.Errorf("after %d attempts, last error: %s", attempts, err)
 }
 
+func (c *KubernetesTestClient) DeletePVCs(containsString string) error {
+	pvcs, err := c.CoreV1().PersistentVolumeClaims("").List(metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	for _, pvc := range pvcs.Items {
+		if strings.Contains(pvc.GetName(), containsString) {
+			err = c.CoreV1().PersistentVolumeClaims(pvc.GetNamespace()).Delete(pvc.GetName(), &metav1.DeleteOptions{})
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 func (c *KubernetesTestClient) ExecInPod(namespace string, podName string, containerName string, commands []string) (string, error) {
 	req := c.CoreV1().RESTClient().Post().
 		Namespace(namespace).

--- a/tests/utils/client.go
+++ b/tests/utils/client.go
@@ -233,9 +233,15 @@ func (c *KubernetesTestClient) GetServicesCount(name string, namespace string) i
 }
 
 func Setup(namespace string) {
-	InstallKudoOperator(namespace, ZK_INSTANCE, ZK_FRAMEWORK_DIR_ENV, map[string]string{})
+	InstallKudoOperator(namespace, ZK_INSTANCE, ZK_FRAMEWORK_DIR_ENV, map[string]string{
+		"MEMORY": "256Mi",
+		"CPUS":   "0.25",
+	})
 	KClient.WaitForStatefulSetCount(suites.DefaultZkStatefulSetName, namespace, 3, 30)
-	InstallKudoOperator(namespace, KAFKA_INSTANCE, KAFKA_FRAMEWORK_DIR_ENV, map[string]string{})
+	InstallKudoOperator(namespace, KAFKA_INSTANCE, KAFKA_FRAMEWORK_DIR_ENV, map[string]string{
+		"BROKER_MEM":  "1Gi",
+		"BROKER_CPUS": "0.25",
+	})
 	KClient.WaitForStatefulSetCount(suites.DefaultKafkaStatefulSetName, namespace, 3, 30)
 }
 

--- a/tests/utils/kafka.go
+++ b/tests/utils/kafka.go
@@ -219,6 +219,10 @@ func DeleteInstances(namespace, name string) {
 	KClient.DeleteInstance(namespace, name)
 }
 
+func DeletePVCs(containsString string) error {
+	return KClient.DeletePVCs(containsString)
+}
+
 func GetKafkaKeyabs(namespace string) []string {
 	return []string{
 		"livenessProbe/kafka-kafka-0.kafka-svc." + namespace + ".svc.cluster.local@LOCAL",


### PR DESCRIPTION
this PR 
- adds tests to verify that pvc has `ReadWriteOnce` mode only 
- verify all the configmaps that are mounted using configmap 