### PR TITLE
Added test to update LOG_RETENTION_HOURS parameter

### DIFF
--- a/tests/suites/kafka_sanity/kafka_broker_test.go
+++ b/tests/suites/kafka_sanity/kafka_broker_test.go
@@ -208,6 +208,33 @@ var _ = Describe("KafkaTest", func() {
 			})
 		})
 
+		Context("Update LOG_RETENTION_HOURS param from default 168 to 200", func() {
+			It("LOG_RETENTION_HOURS should change from 168 to 200", func() {
+				currentParamVal, _ := utils.KClient.GetParamForKudoInstance(DefaultKudoKafkaInstance, customNamespace,"LOG_RETENTION_HOURS")
+				log.Printf("Current Parameter %s value is : %s ", "LOG_RETENTION_HOURS", currentParamVal)
+				err := utils.KClient.UpdateInstanceParams(DefaultKudoKafkaInstance, customNamespace, map[string]string{"LOG_RETENTION_HOURS": "200"})
+				Expect(err).To(BeNil())
+				err = utils.KClient.WaitForReadyStatus(DefaultKudoKafkaInstance, customNamespace, 240)
+				Expect(err).To(BeNil())
+				updatedParamVal := "200"
+				Expect(updatedParamVal).NotTo(Equal(currentParamVal))
+				Expect(utils.KClient.GetParamForKudoInstance(DefaultKudoKafkaInstance, customNamespace,"LOG_RETENTION_HOURS")).To(Equal("200"))
+			})
+			It("statefulset should have 3 replicas", func() {
+				Expect(utils.KClient.GetStatefulSetCount(DefaultKafkaStatefulSetName, customNamespace)).To(Equal(3))
+			})
+			It("should have 3 replicas with status READY", func() {
+				err := utils.KClient.WaitForStatefulSetReadyReplicasCount(DefaultZkStatefulSetName, customNamespace, 3, 240)
+				Expect(err).To(BeNil())
+				err = utils.KClient.WaitForStatefulSetReadyReplicasCount(DefaultKafkaStatefulSetName, customNamespace, 3, 240)
+				Expect(err).To(BeNil())
+				Expect(utils.KClient.GetStatefulSetCount(DefaultKafkaStatefulSetName, customNamespace)).To(Equal(3))
+			})
+			It("Check parameter value again", func() {
+				Expect(utils.KClient.GetParamForKudoInstance(DefaultKudoKafkaInstance, customNamespace,"LOG_RETENTION_HOURS")).To(Equal("200"))
+			})
+		})
+
 	})
 })
 

--- a/tests/suites/kafka_sanity/kafka_broker_test.go
+++ b/tests/suites/kafka_sanity/kafka_broker_test.go
@@ -210,7 +210,7 @@ var _ = Describe("KafkaTest", func() {
 
 		Context("Update LOG_RETENTION_HOURS param from default 168 to 200", func() {
 			It("LOG_RETENTION_HOURS should change from 168 to 200", func() {
-				currentParamVal, _ := utils.KClient.GetParamForKudoInstance(DefaultKudoKafkaInstance, customNamespace,"LOG_RETENTION_HOURS")
+				currentParamVal, _ := utils.KClient.GetParamForKudoInstance(DefaultKudoKafkaInstance, customNamespace, "LOG_RETENTION_HOURS")
 				log.Printf("Current Parameter %s value is : %s ", "LOG_RETENTION_HOURS", currentParamVal)
 				err := utils.KClient.UpdateInstanceParams(DefaultKudoKafkaInstance, customNamespace, map[string]string{"LOG_RETENTION_HOURS": "200"})
 				Expect(err).To(BeNil())
@@ -218,7 +218,7 @@ var _ = Describe("KafkaTest", func() {
 				Expect(err).To(BeNil())
 				updatedParamVal := "200"
 				Expect(updatedParamVal).NotTo(Equal(currentParamVal))
-				Expect(utils.KClient.GetParamForKudoInstance(DefaultKudoKafkaInstance, customNamespace,"LOG_RETENTION_HOURS")).To(Equal("200"))
+				Expect(utils.KClient.GetParamForKudoInstance(DefaultKudoKafkaInstance, customNamespace, "LOG_RETENTION_HOURS")).To(Equal("200"))
 			})
 			It("statefulset should have 3 replicas", func() {
 				Expect(utils.KClient.GetStatefulSetCount(DefaultKafkaStatefulSetName, customNamespace)).To(Equal(3))
@@ -231,7 +231,7 @@ var _ = Describe("KafkaTest", func() {
 				Expect(utils.KClient.GetStatefulSetCount(DefaultKafkaStatefulSetName, customNamespace)).To(Equal(3))
 			})
 			It("Check parameter value again", func() {
-				Expect(utils.KClient.GetParamForKudoInstance(DefaultKudoKafkaInstance, customNamespace,"LOG_RETENTION_HOURS")).To(Equal("200"))
+				Expect(utils.KClient.GetParamForKudoInstance(DefaultKudoKafkaInstance, customNamespace, "LOG_RETENTION_HOURS")).To(Equal("200"))
 			})
 		})
 

--- a/tests/suites/kafka_sanity/kafka_broker_test.go
+++ b/tests/suites/kafka_sanity/kafka_broker_test.go
@@ -236,6 +236,7 @@ var _ = Describe("KafkaTest", func() {
 			It("Check parameter value again", func() {
 				out, err := kafkaClient.ExecInPod(customNamespace, GetBrokerPodName(0), DefaultContainerName,
 					[]string{"grep", "log.retention.hours", "/var/lib/kafka/data/server.log"})
+				Expect(err).To(BeNil())
 				Expect(out).To(ContainSubstring(fmt.Sprintf("%s = %s", "log.retention.hours", "200")))
 			})
 		})

--- a/tests/suites/kafka_sanity/kafka_broker_test.go
+++ b/tests/suites/kafka_sanity/kafka_broker_test.go
@@ -209,6 +209,9 @@ var _ = Describe("KafkaTest", func() {
 		})
 
 		Context("Update LOG_RETENTION_HOURS param from default 168 to 200", func() {
+			kafkaClient := utils.NewKafkaClient(utils.KClient, &utils.KafkaClientConfiguration{
+				Namespace: utils.String(customNamespace),
+			})
 			It("LOG_RETENTION_HOURS should change from 168 to 200", func() {
 				currentParamVal, _ := utils.KClient.GetParamForKudoInstance(DefaultKudoKafkaInstance, customNamespace, "LOG_RETENTION_HOURS")
 				log.Printf("Current Parameter %s value is : %s ", "LOG_RETENTION_HOURS", currentParamVal)
@@ -231,7 +234,9 @@ var _ = Describe("KafkaTest", func() {
 				Expect(utils.KClient.GetStatefulSetCount(DefaultKafkaStatefulSetName, customNamespace)).To(Equal(3))
 			})
 			It("Check parameter value again", func() {
-				Expect(utils.KClient.GetParamForKudoInstance(DefaultKudoKafkaInstance, customNamespace, "LOG_RETENTION_HOURS")).To(Equal("200"))
+				out, err := kafkaClient.ExecInPod(customNamespace, GetBrokerPodName(0), DefaultContainerName,
+				[]string{"grep", "log.retention.hours", "/opt/kafka/server.properties"})
+				Expect(out).To(ContainSubstring(fmt.Sprintf("%s=%s", "log.retention.hours", "200")))
 			})
 		})
 

--- a/tests/suites/kafka_sanity/kafka_broker_test.go
+++ b/tests/suites/kafka_sanity/kafka_broker_test.go
@@ -235,8 +235,8 @@ var _ = Describe("KafkaTest", func() {
 			})
 			It("Check parameter value again", func() {
 				out, err := kafkaClient.ExecInPod(customNamespace, GetBrokerPodName(0), DefaultContainerName,
-				[]string{"grep", "log.retention.hours", "/opt/kafka/server.properties"})
-				Expect(out).To(ContainSubstring(fmt.Sprintf("%s=%s", "log.retention.hours", "200")))
+					[]string{"grep", "log.retention.hours", "/var/lib/kafka/data/server.log"})
+				Expect(out).To(ContainSubstring(fmt.Sprintf("%s = %s", "log.retention.hours", "200")))
 			})
 		})
 


### PR DESCRIPTION
This PR adds a new test with the context:

1. To update the value of `LOG_RETENTION_HOURS` from default `168` to `200`
2. To check if there are 3 nodes running after update
3. To check if statefulset is in ready state after parameter value update
4. To check if the value of `LOG_RETENTION_HOURS` is changed after updation successfully.

This PR also adds a new function for Kudo TestClient named `UpdateInstanceParams` which takes a map of parameter names and their values that needs to be updated in a given instance name.

Signed-off-by: Vibhu Jain <vibhujain.j@gmail.com>