### PR TITLE
Add run-pre-checks 

### DIFF
--- a/run-pre-checks.sh
+++ b/run-pre-checks.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+readonly script_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+readonly project_directory="$(readlink -f "${script_directory}")"
+
+FAILED=0
+
+go get golang.org/x/tools/cmd/goimports
+goimports -d . | awk 'BEGIN{had_data=0}{print;had_data=1}END{exit had_data}'
+
+FAILED=${FAILED-$?}
+
+exit ${FAILED}


### PR DESCRIPTION
Includes only the goimports check currently.

If we find more checks that can be executed before the konvoy cluster is created, we can add them here