### PR TITLE
Create a CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# The following list of usernames are owners of this project
+# and will be tagged as reviewers when you create a PR:
+
+*   @zmalik @nfnt @ANeumann82 @porridge
+
+# Read about the file in the guide - https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners


### PR DESCRIPTION
Save us the hassle of assigning reviewers by hand each time.