### PR TITLE
enhance the external access support

### DIFF
--- a/docs/external-access.md
+++ b/docs/external-access.md
@@ -257,4 +257,24 @@ inter.broker.listener.name=INTERNAL
 [ ... lines removed for clarity ...]
 ```
 
-##### 
+# External-dns and third-party annotations
+
+KUDO Kafka supports adding annotations to the services created for external access.
+
+For example for external-dns, user can use the parameter `EXTERNAL_SERVICE_ANNOTATIONS` with value:
+
+```
+- external-dns.alpha.kubernetes.io/hostname: my-broker-0.example.org
+- external-dns.alpha.kubernetes.io/hostname: my-broker-1.example.org
+- external-dns.alpha.kubernetes.io/hostname: my-broker-2.example.org
+```
+
+This will add the annotation to first three services used for external access. If the KUDO Kafka cluster is of 5 brokers, the parameter value will look like:
+
+```
+- external-dns.alpha.kubernetes.io/hostname: my-broker-0.example.org
+- external-dns.alpha.kubernetes.io/hostname: my-broker-1.example.org
+- external-dns.alpha.kubernetes.io/hostname: my-broker-2.example.org
+- external-dns.alpha.kubernetes.io/hostname: my-broker-3.example.org
+- external-dns.alpha.kubernetes.io/hostname: my-broker-4.example.org
+```

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -2,6 +2,11 @@
 
 ## latest
 
+- Support node internal IP for external access
+- Support annotations for external access services
+
+## v1.3.2
+
 - Apache Kafka upgraded to 2.5.1
 
 ## v1.3.1

--- a/images/kafka/kafka-utils/pkgs/mocks/environment_mock.go
+++ b/images/kafka/kafka-utils/pkgs/mocks/environment_mock.go
@@ -5,8 +5,9 @@
 package mocks
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockEnvironment is a mock of Environment interface

--- a/images/kafka/kafka-utils/pkgs/mocks/environment_mock.go
+++ b/images/kafka/kafka-utils/pkgs/mocks/environment_mock.go
@@ -5,9 +5,8 @@
 package mocks
 
 import (
-	"github.com/golang/mock/gomock"
-
-	"reflect"
+	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockEnvironment is a mock of Environment interface
@@ -87,4 +86,18 @@ func (m *MockEnvironment) GetNodeName() string {
 func (mr *MockEnvironmentMockRecorder) GetNodeName() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeName", reflect.TypeOf((*MockEnvironment)(nil).GetNodeName))
+}
+
+// GetNodePortIPType mocks base method
+func (m *MockEnvironment) GetNodePortIPType() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNodePortIPType")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetNodePortIPType indicates an expected call of GetNodePortIPType
+func (mr *MockEnvironmentMockRecorder) GetNodePortIPType() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodePortIPType", reflect.TypeOf((*MockEnvironment)(nil).GetNodePortIPType))
 }

--- a/images/kafka/kafka-utils/pkgs/service/environment.go
+++ b/images/kafka/kafka-utils/pkgs/service/environment.go
@@ -9,6 +9,7 @@ type Environment interface {
 	GetNamespace() string
 	GetExternalIngressPort() string
 	GetNodeName() string
+	GetNodePortIPType() string
 }
 
 type EnvironmentImpl struct{}
@@ -27,4 +28,8 @@ func (c *EnvironmentImpl) GetExternalIngressPort() string {
 
 func (c *EnvironmentImpl) GetNodeName() string {
 	return os.Getenv("NODE_NAME")
+}
+
+func (c *EnvironmentImpl) GetNodePortIPType() string {
+	return os.Getenv("EXTERNAL_NODEPORT_IP_TYPE")
 }

--- a/images/kafka/kafka-utils/pkgs/service/service_test.go
+++ b/images/kafka/kafka-utils/pkgs/service/service_test.go
@@ -28,147 +28,214 @@ var _ = Describe("[Kafka KafkaService]", func() {
 		mockEnv  *mocks.MockEnvironment
 	)
 
-	Context("External Access Configuration", func() {
-		tests := []struct {
-			svc                                 *v1.ServiceList
-			node                                *v1.Node
-			name                                string
-			expectedAdvertisedListeners         string
-			expectedListeners                   string
-			expectedListenerSecurityProtocolMap string
-			expectedExternalDNS                 string
-		}{
-			{
-				name: "Type LoadBalancer AWS",
-				svc: &v1.ServiceList{
-					Items: []v1.Service{
-						{
-							ObjectMeta: metav1.ObjectMeta{
-								Name:      "kafka-kafka-0-external",
-								Namespace: v1.NamespaceDefault,
-							},
-							Spec: v1.ServiceSpec{
-								Type: v1.ServiceTypeLoadBalancer,
-							},
-							Status: v1.ServiceStatus{
-								LoadBalancer: v1.LoadBalancerStatus{
-									Ingress: []v1.LoadBalancerIngress{
-										{
-											Hostname: "aws.kafka.dns-kafka-kafka-0",
-										},
-									},
-								},
-							},
+	tests := []struct {
+		svc                                 *v1.ServiceList
+		node                                *v1.Node
+		name                                string
+		expectedAdvertisedListeners         string
+		expectedListeners                   string
+		expectedListenerSecurityProtocolMap string
+		expectedExternalDNS                 string
+		nodeportIpType                      string
+	}{
+		{
+			name: "Type LoadBalancer AWS",
+			svc: &v1.ServiceList{
+				Items: []v1.Service{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "kafka-kafka-0-external",
+							Namespace: v1.NamespaceDefault,
 						},
-					},
-				},
-				node:                                &v1.Node{},
-				expectedAdvertisedListeners:         "EXTERNAL_INGRESS://aws.kafka.dns-kafka-kafka-0:9097",
-				expectedListeners:                   "EXTERNAL_INGRESS://0.0.0.0:9097",
-				expectedExternalDNS:                 "aws.kafka.dns-kafka-kafka-0",
-				expectedListenerSecurityProtocolMap: "EXTERNAL_INGRESS:PLAINTEXT",
-			},
-			{
-				name: "Type LoadBalancer GCE",
-				svc: &v1.ServiceList{
-					Items: []v1.Service{
-						{
-							ObjectMeta: metav1.ObjectMeta{
-								Name:      "kafka-kafka-0-external",
-								Namespace: v1.NamespaceDefault,
-							},
-							Spec: v1.ServiceSpec{
-								Type: v1.ServiceTypeLoadBalancer,
-							},
-							Status: v1.ServiceStatus{
-								LoadBalancer: v1.LoadBalancerStatus{
-									Ingress: []v1.LoadBalancerIngress{
-										{
-											IP: "30.0.0.1",
-										},
-									},
-								},
-							},
+						Spec: v1.ServiceSpec{
+							Type: v1.ServiceTypeLoadBalancer,
 						},
-					},
-				},
-				node:                                &v1.Node{},
-				expectedAdvertisedListeners:         "EXTERNAL_INGRESS://30.0.0.1:9097",
-				expectedListeners:                   "EXTERNAL_INGRESS://0.0.0.0:9097",
-				expectedExternalDNS:                 "30.0.0.1",
-				expectedListenerSecurityProtocolMap: "EXTERNAL_INGRESS:PLAINTEXT",
-			},
-			{
-				name: "Type NodePort",
-				svc: &v1.ServiceList{
-					Items: []v1.Service{
-						{
-							ObjectMeta: metav1.ObjectMeta{
-								Name:      "kafka-kafka-0-external",
-								Namespace: v1.NamespaceDefault,
-							},
-							Spec: v1.ServiceSpec{
-								Type: v1.ServiceTypeNodePort,
-								Ports: []v1.ServicePort{
+						Status: v1.ServiceStatus{
+							LoadBalancer: v1.LoadBalancerStatus{
+								Ingress: []v1.LoadBalancerIngress{
 									{
-										Port:     31002,
-										NodePort: 31002,
-									},
-								},
-							},
-							Status: v1.ServiceStatus{
-								LoadBalancer: v1.LoadBalancerStatus{
-									Ingress: []v1.LoadBalancerIngress{
-										{
-											IP: "10.0.0.1",
-										},
+										Hostname: "aws.kafka.dns-kafka-kafka-0",
 									},
 								},
 							},
 						},
 					},
 				},
-				node: &v1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "kubelet-0",
-					},
-					Status: v1.NodeStatus{
-						Addresses: []v1.NodeAddress{
-							{
-								Type:    v1.NodeExternalIP,
-								Address: "30.0.0.1",
+			},
+			node:                                &v1.Node{},
+			expectedAdvertisedListeners:         "EXTERNAL_INGRESS://aws.kafka.dns-kafka-kafka-0:9097",
+			expectedListeners:                   "EXTERNAL_INGRESS://0.0.0.0:9097",
+			expectedExternalDNS:                 "aws.kafka.dns-kafka-kafka-0",
+			expectedListenerSecurityProtocolMap: "EXTERNAL_INGRESS:PLAINTEXT",
+		},
+		{
+			name: "Type LoadBalancer GCE",
+			svc: &v1.ServiceList{
+				Items: []v1.Service{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "kafka-kafka-0-external",
+							Namespace: v1.NamespaceDefault,
+						},
+						Spec: v1.ServiceSpec{
+							Type: v1.ServiceTypeLoadBalancer,
+						},
+						Status: v1.ServiceStatus{
+							LoadBalancer: v1.LoadBalancerStatus{
+								Ingress: []v1.LoadBalancerIngress{
+									{
+										IP: "30.0.0.1",
+									},
+								},
 							},
 						},
 					},
 				},
-				expectedAdvertisedListeners:         "EXTERNAL_INGRESS://30.0.0.1:31002",
-				expectedListeners:                   "EXTERNAL_INGRESS://0.0.0.0:31002",
-				expectedExternalDNS:                 "30.0.0.1",
-				expectedListenerSecurityProtocolMap: "EXTERNAL_INGRESS:PLAINTEXT",
 			},
-			{
-				name: "No external Service",
-				svc:  &v1.ServiceList{},
-				node: &v1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "kubelet-0",
-					},
-					Status: v1.NodeStatus{
-						Addresses: []v1.NodeAddress{
-							{
-								Type:    v1.NodeExternalIP,
-								Address: "30.0.0.1",
+			node:                                &v1.Node{},
+			expectedAdvertisedListeners:         "EXTERNAL_INGRESS://30.0.0.1:9097",
+			expectedListeners:                   "EXTERNAL_INGRESS://0.0.0.0:9097",
+			expectedExternalDNS:                 "30.0.0.1",
+			expectedListenerSecurityProtocolMap: "EXTERNAL_INGRESS:PLAINTEXT",
+		},
+		{
+			name: "Type NodePort External IP",
+			svc: &v1.ServiceList{
+				Items: []v1.Service{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "kafka-kafka-0-external",
+							Namespace: v1.NamespaceDefault,
+						},
+						Spec: v1.ServiceSpec{
+							Type: v1.ServiceTypeNodePort,
+							Ports: []v1.ServicePort{
+								{
+									Port:     31002,
+									NodePort: 31002,
+								},
+							},
+						},
+						Status: v1.ServiceStatus{
+							LoadBalancer: v1.LoadBalancerStatus{
+								Ingress: []v1.LoadBalancerIngress{
+									{
+										IP: "10.0.0.1",
+									},
+								},
 							},
 						},
 					},
 				},
-				expectedAdvertisedListeners:         "",
-				expectedListeners:                   "",
-				expectedExternalDNS:                 "",
-				expectedListenerSecurityProtocolMap: "",
 			},
-		}
+			node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "kubelet-0",
+				},
+				Status: v1.NodeStatus{
+					Addresses: []v1.NodeAddress{
+						{
+							Type:    v1.NodeExternalIP,
+							Address: "30.0.0.1",
+						},
+					},
+				},
+			},
+			expectedAdvertisedListeners:         "EXTERNAL_INGRESS://30.0.0.1:31002",
+			expectedListeners:                   "EXTERNAL_INGRESS://0.0.0.0:31002",
+			expectedExternalDNS:                 "30.0.0.1",
+			expectedListenerSecurityProtocolMap: "EXTERNAL_INGRESS:PLAINTEXT",
+			nodeportIpType:                      "EXTERNAL",
+		},
+		{
+			name: "Type NodePort Internal IP",
+			svc: &v1.ServiceList{
+				Items: []v1.Service{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "kafka-kafka-0-external",
+							Namespace: v1.NamespaceDefault,
+						},
+						Spec: v1.ServiceSpec{
+							Type: v1.ServiceTypeNodePort,
+							Ports: []v1.ServicePort{
+								{
+									Port:     31002,
+									NodePort: 31002,
+								},
+							},
+						},
+						Status: v1.ServiceStatus{
+							LoadBalancer: v1.LoadBalancerStatus{
+								Ingress: []v1.LoadBalancerIngress{
+									{
+										IP: "10.0.0.1",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "kubelet-0",
+				},
+				Status: v1.NodeStatus{
+					Addresses: []v1.NodeAddress{
+						{
+							Type:    v1.NodeInternalIP,
+							Address: "10.0.0.1",
+						},
+					},
+				},
+			},
+			expectedAdvertisedListeners:         "EXTERNAL_INGRESS://10.0.0.1:31002",
+			expectedListeners:                   "EXTERNAL_INGRESS://0.0.0.0:31002",
+			expectedExternalDNS:                 "10.0.0.1",
+			expectedListenerSecurityProtocolMap: "EXTERNAL_INGRESS:PLAINTEXT",
+			nodeportIpType:                      "INTERNAL",
+		},
+		{
+			name: "No external Service",
+			svc:  &v1.ServiceList{},
+			node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "kubelet-0",
+				},
+				Status: v1.NodeStatus{
+					Addresses: []v1.NodeAddress{
+						{
+							Type:    v1.NodeExternalIP,
+							Address: "30.0.0.1",
+						},
+					},
+				},
+			},
+			expectedAdvertisedListeners:         "",
+			expectedListeners:                   "",
+			expectedExternalDNS:                 "",
+			expectedListenerSecurityProtocolMap: "",
+		},
+	}
+	Context("external Access Configuration", func() {
+
+		BeforeEach(func() {
+			mockCtrl = gomock.NewController(GinkgoT())
+			mockEnv = mocks.NewMockEnvironment(mockCtrl)
+
+			mockEnv.EXPECT().GetNamespace().Return("default").AnyTimes()
+			mockEnv.EXPECT().GetExternalIngressPort().Return("9097").AnyTimes()
+			mockEnv.EXPECT().GetNodeName().Return("kubelet-0").AnyTimes()
+			mockEnv.EXPECT().GetHostName().Return("localhost").AnyTimes()
+		})
+
+		AfterEach(func() {
+			mockCtrl.Finish()
+		})
+
 		for _, test := range tests {
+			test := test //necessary to ensure the correct value is passed to the closure
 			It(test.name, func() {
 				kafkaService := KafkaService{
 					Client: testclient.NewSimpleClientset(test.svc, test.node),
@@ -180,6 +247,8 @@ var _ = Describe("[Kafka KafkaService]", func() {
 					log.Fatal(err)
 				}
 				os.Setenv("LISTENER_SECURITY_PROTOCOL_MAP", "INTERNAL:PLAINTEXT")
+				os.Setenv("EXTERNAL_NODEPORT_IP_TYPE", test.nodeportIpType)
+				mockEnv.EXPECT().GetNodePortIPType().Return(os.Getenv("EXTERNAL_NODEPORT_IP_TYPE")).AnyTimes()
 				err = kafkaService.WriteIngressToPath(dir)
 				Expect(err).To(BeNil())
 
@@ -197,20 +266,6 @@ var _ = Describe("[Kafka KafkaService]", func() {
 
 			})
 		}
-	})
-
-	BeforeEach(func() {
-		mockCtrl = gomock.NewController(GinkgoT())
-		mockEnv = mocks.NewMockEnvironment(mockCtrl)
-
-		mockEnv.EXPECT().GetNamespace().Return("default").AnyTimes()
-		mockEnv.EXPECT().GetExternalIngressPort().Return("9097").AnyTimes()
-		mockEnv.EXPECT().GetNodeName().Return("kubelet-0").AnyTimes()
-		mockEnv.EXPECT().GetHostName().Return("localhost").AnyTimes()
-	})
-
-	AfterEach(func() {
-		mockCtrl.Finish()
 	})
 })
 

--- a/kuttl-tests/suites/upgrade/01-install.yaml
+++ b/kuttl-tests/suites/upgrade/01-install.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kafka
 spec:
   operatorVersion:
-    name: kafka-1.3.2
+    name: kafka-1.3.3
     namespace: default
     kind: OperatorVersion
   name: "kafka"

--- a/kuttl-tests/suites/upgrade/02-resize.yaml
+++ b/kuttl-tests/suites/upgrade/02-resize.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kafka
 spec:
   operatorVersion:
-    name: kafka-1.3.2
+    name: kafka-1.3.3
     namespace: default
     kind: OperatorVersion
   name: "kafka"

--- a/operator/operator.yaml
+++ b/operator/operator.yaml
@@ -1,6 +1,6 @@
 apiVersion: kudo.dev/v1beta1
 name: "kafka"
-operatorVersion: "1.3.2"
+operatorVersion: "1.3.3"
 kudoVersion: 0.14.0
 kubernetesVersion: 1.16.0
 appVersion: 2.5.1

--- a/operator/params.yaml
+++ b/operator/params.yaml
@@ -558,6 +558,18 @@ parameters:
     default: "30902"
     displayName: "External Node Port starting value."
     trigger: "external-access"
+  - name: EXTERNAL_NODEPORT_IP_TYPE
+    default: "EXTERNAL"
+    description: |
+        Nodeport IP Type, defines which IP type to use when using external access through Node Port.
+        when using default 'EXTERNAL' the external IP of the node will be used to populate the advertised.listeners
+        when using 'INTERNAL' the node internal IP will be added to advertised.listeners
+  - name: EXTERNAL_SERVICE_ANNOTATIONS
+    type: array
+    required: False
+    description: |
+      Custom annotations for the external services created for external access.
+    trigger: "external-access"
   - name: FETCH_PURGATORY_PURGE_INTERVAL_REQUESTS
     displayName: "fetch.purgatory.purge.interval.requests"
     description: "The purge interval (in number of requests) of the fetch request purgatory"

--- a/operator/templates/external-service.yaml
+++ b/operator/templates/external-service.yaml
@@ -5,6 +5,10 @@ kind: Service
 metadata:
   name: {{ $.Name }}-kafka-{{ $v }}-external
   namespace: {{ $.Namespace }}
+  {{- if $.Params.EXTERNAL_SERVICE_ANNOTATIONS }}
+  annotations:
+    {{ toYaml (index $.Params.EXTERNAL_SERVICE_ANNOTATIONS $v)  }}
+  {{- end }}
 spec:
   type: {{ $.Params.EXTERNAL_ADVERTISED_LISTENER_TYPE }}
   externalTrafficPolicy: Local

--- a/operator/templates/statefulset.yaml
+++ b/operator/templates/statefulset.yaml
@@ -147,6 +147,8 @@ spec:
               value: "{{ .Params.CLIENT_PORT }}"
             - name: EXTERNAL_INGRESS_PORT
               value: "{{ .Params.EXTERNAL_ADVERTISED_LISTENER_PORT }}"
+            - name: EXTERNAL_NODEPORT_IP_TYPE
+              value: "{{ .Params.EXTERNAL_NODEPORT_IP_TYPE }}"
             - name: NAMESPACE
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
This PR 
- add support for adding annotations to the external services 
- add support for node internal IP using the parameter `EXTERNAL_NODEPORT_IP_TYPE `