### PR TITLE
Use OperatorVersion names that include app version (KUDO >= 0.17)

### DIFF
--- a/kuttl-tests/suites/upgrade/00-install.yaml
+++ b/kuttl-tests/suites/upgrade/00-install.yaml
@@ -4,7 +4,7 @@ metadata:
   name: zk
 spec:
   operatorVersion:
-    name: zookeeper-0.3.1
+    name: zookeeper-3.4.14-0.3.1
     namespace: default
     kind: OperatorVersion
   name: "zk"

--- a/kuttl-tests/suites/upgrade/01-install.yaml
+++ b/kuttl-tests/suites/upgrade/01-install.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kafka
 spec:
   operatorVersion:
-    name: kafka-1.3.2
+    name: kafka-2.5.1-1.3.2
     namespace: default
     kind: OperatorVersion
   name: "kafka"

--- a/kuttl-tests/suites/upgrade/02-resize.yaml
+++ b/kuttl-tests/suites/upgrade/02-resize.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kafka
 spec:
   operatorVersion:
-    name: kafka-1.3.2
+    name: kafka-2.5.1-1.3.2
     namespace: default
     kind: OperatorVersion
   name: "kafka"


### PR DESCRIPTION
To be merged once KUDO 0.17 has been released and is the default version this repository is tested with.