### PR TITLE
 Make the image pull policy configurable

### DIFF
--- a/kuttl-tests/suites/upgrade/01-install.yaml
+++ b/kuttl-tests/suites/upgrade/01-install.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kafka
 spec:
   operatorVersion:
-    name: kafka-1.3.2
+    name: kafka-1.3.3
     namespace: default
     kind: OperatorVersion
   name: "kafka"

--- a/kuttl-tests/suites/upgrade/02-resize.yaml
+++ b/kuttl-tests/suites/upgrade/02-resize.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kafka
 spec:
   operatorVersion:
-    name: kafka-1.3.2
+    name: kafka-1.3.3
     namespace: default
     kind: OperatorVersion
   name: "kafka"

--- a/operator/operator.yaml
+++ b/operator/operator.yaml
@@ -1,6 +1,6 @@
 apiVersion: kudo.dev/v1beta1
 name: "kafka"
-operatorVersion: "1.3.2"
+operatorVersion: "1.3.3"
 kudoVersion: 0.14.0
 kubernetesVersion: 1.16.0
 appVersion: 2.5.1

--- a/operator/params.yaml
+++ b/operator/params.yaml
@@ -814,6 +814,12 @@ parameters:
     description: "These metrics prometheus rules to be used instead of the default metrics rules."
     required: false
     trigger: "update-instance"
+  - name: KAFKA_IMAGE_PULL_POLICY
+    description: "Kafka container image pull policy"
+    default: "Always"
+  - name: KAFKA_WORKLOAD_IMAGE_PULL_POLICY
+    description: "Kafka workload container image pull policy"
+    default: "Always"
   - name: MIRROR_MAKER_ENABLED
     default: "false"
     trigger: "mirrormaker"
@@ -910,6 +916,9 @@ parameters:
     description: "Kafka Connect topic offset flush interval in milliseconds"
     default: 10000
     trigger: "kafka-connect"
+  - name: KAFKA_CONNECT_IMAGE_PULL_POLICY
+    description: "Kafka Connect container image pull policy"
+    default: "Always"
   - name: ENABLE_CRUISE_CONTROL
     description: "Enable cruise control for the current KUDO Kafka cluster"
     default: "false"
@@ -942,3 +951,6 @@ parameters:
     description: "Cruise Control REST Web UI default path prefix"
     default: "/*"
     trigger: "cruise-control"
+  - name: CRUISE_CONTROL_IMAGE_PULL_POLICY
+    description: "Cruise Control container image pull policy"
+    default: "Always"

--- a/operator/templates/cruise-control.yaml
+++ b/operator/templates/cruise-control.yaml
@@ -19,7 +19,7 @@ spec:
       containers:
       - name: cruise-control
         image: mesosphere/cruise-control:2.0.77-1.3.0
-        imagePullPolicy: Always
+        imagePullPolicy: {{ .Params.CRUISE_CONTROL_IMAGE_PULL_POLICY }}
         ports:
         - name: http
           containerPort: {{ .Params.CRUISE_CONTROL_PORT }}

--- a/operator/templates/kafka-connect-setup.yaml
+++ b/operator/templates/kafka-connect-setup.yaml
@@ -14,7 +14,7 @@ spec:
       containers:
       - name: kafka-connect-setup
         image: shubhanilbag/kafka:2.4.0-1.3.0
-        imagePullPolicy: Always
+        imagePullPolicy: {{ .Params.KAFKA_CONNECT_IMAGE_PULL_POLICY }}
         resources:
           requests:
             cpu: 100m

--- a/operator/templates/kafka-connect.yaml
+++ b/operator/templates/kafka-connect.yaml
@@ -18,7 +18,7 @@ spec:
       containers:
       - name: kafka-connect
         image: mesosphere/kafka:2.5.1-1.3.1
-        imagePullPolicy: Always
+        imagePullPolicy: {{ .Params.KAFKA_IMAGE_PULL_POLICY }}
         resources:
           requests:
             cpu: {{ .Params.KAFKA_CONNECT_CPUS }}

--- a/operator/templates/mirror-maker.yaml
+++ b/operator/templates/mirror-maker.yaml
@@ -18,7 +18,7 @@ spec:
       containers:
       - name: kafka-mirror-maker
         image: mesosphere/kafka:2.5.1-1.3.1
-        imagePullPolicy: Always
+        imagePullPolicy: {{ .Params.KAFKA_IMAGE_PULL_POLICY }}
         command:
           - bash
           - -c

--- a/operator/templates/statefulset.yaml
+++ b/operator/templates/statefulset.yaml
@@ -80,7 +80,7 @@ spec:
             - --no-collector.zfs
         {{ end }}
         - name: k8skafka
-          imagePullPolicy: Always
+          imagePullPolicy: {{ .Params.KAFKA_IMAGE_PULL_POLICY }}
           image: mesosphere/kafka:2.5.1-1.3.1
           resources:
             requests:

--- a/operator/templates/user-workload.yaml
+++ b/operator/templates/user-workload.yaml
@@ -18,7 +18,7 @@ spec:
       containers:
       - name: kafka-ultron-loader
         image: mesosphere/kafka:workload
-        imagePullPolicy: Always
+        imagePullPolicy: {{ .Params.KAFKA_WORKLOAD_IMAGE_PULL_POLICY }}
         command:
         - /opt/kafka/run_producer_test.sh
         env:


### PR DESCRIPTION
This adds parameters to allow users to change the image pull policy of all container images used by the operator.

As requested in https://github.com/kudobuilder/operators/issues/247