### PR TITLE
Default to using the number of brokers we create.

### DIFF
--- a/operator/params.yaml
+++ b/operator/params.yaml
@@ -535,7 +535,7 @@ parameters:
   - name: DEFAULT_REPLICATION_FACTOR
     displayName: "default.replication.factor"
     description: "Default replication factors for automatically created topics"
-    default: "1"
+    default: "3"
     trigger: "update-instance"
   - name: EXTERNAL_ADVERTISED_LISTENER
     displayName: "Enable external advertised listeners"


### PR DESCRIPTION
By default, the operator creates a 3 node cluster, but default replication factor is currently set to 1, ie no replication at all.
This creates a dangerous situation where creating a cluster with the defaults can give the impression that having multiple brokers means there is some protection from hardware failure, where there is none.
A safer default is to match the number of brokers.