### PR TITLE
Updates/fixes related to Kerberos authentication

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -90,9 +90,10 @@ Kerberos authentication relies on a central authority to verify that Kafka clien
 
 The KUDO Kafka service requires a Kerberos principal for each broker to be deployed. Each principal must be of the form
 ```
-<service primary>/kafka-instance-kafka-<broker index>.kafka-svc.<namespace>.svc.cluster.local@<service realm>
+<service primary>/<instance name>-kafka-<broker index>.<instance name>-svc.<namespace>.svc.cluster.local@<service realm>
 ```
 with:
+* ```instance name = value for --instance flag used in kudo install kafka; defaults to "kafka-instance" ```
 * ```service primary = KERBEROS_PRIMARY```
 * ```broker index = 0 up to BROKER_COUNT - 1```
 * ```namespace = kubernetes namespace```
@@ -114,9 +115,9 @@ $ kubectl kudo install kafka \
 ```
 then the principals to create would be:
 ```
-kafka/kafka-instance-kafka-0.kafka-svc.kudo-kafka.svc.cluster.local@LOCAL
-kafka/kafka-instance-kafka-1.kafka-svc.kudo-kafka.svc.cluster.local@LOCAL
-kafka/kafka-instance-kafka-2.kafka-svc.kudo-kafka.svc.cluster.local@LOCAL
+kafka/kafka-instance-kafka-0.kafka-instance-svc.kudo-kafka.svc.cluster.local@LOCAL
+kafka/kafka-instance-kafka-1.kafka-instance-svc.kudo-kafka.svc.cluster.local@LOCAL
+kafka/kafka-instance-kafka-2.kafka-instance-svc.kudo-kafka.svc.cluster.local@LOCAL
 ```
 
 Use `KERBEROS_USE_TCP=true` parameter to use `TCP` protocol for KDC. By default it will try to use UDP. 
@@ -125,7 +126,7 @@ Use `KERBEROS_USE_TCP=true` parameter to use `TCP` protocol for KDC. By default 
 The KUDO Kafka service uses a keytab containing all node principals (service keytab). After creating the principals above, generate the service keytab making sure to include all the node principals. This should be stored as a secret in the Kubernetes Secret Store using `base64` encoding.
 
 ```
-kubectl create secret generic kdc --from-file=./kafka.keytab
+kubectl create secret generic base64-kafka-keytab-secret --from-file=./kafka.keytab
 ```
 :warning: The KUDO Kafka assume the key in the secret to be `kafka.keytab`
 

--- a/operator/templates/bootstrap.yaml
+++ b/operator/templates/bootstrap.yaml
@@ -11,7 +11,7 @@ data:
     chmod +x health-check.sh;
 
     {{ if eq .Params.KERBEROS_ENABLED "true" }}
-    cat /kafka-keytab/kafka.keytab | base64 --decode > kafka.keytab;
+    cp /kafka-keytab/kafka.keytab $KAFKA_HOME/kafka.keytab;
     cp /jass-config/kafka_server_jaas.conf $KAFKA_HOME/config/kafka_server_jaas.conf;
     cp /krb5-config/krb5.conf $KAFKA_HOME/config/krb5.conf;
     sed -i "s/<HOSTNAME>/$(hostname -f)/g" $KAFKA_HOME/config/kafka_server_jaas.conf;
@@ -81,6 +81,8 @@ data:
     listener.name.client.scram-sha-512.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required;
     EOF
     )
+      elif [[ "$LISTENER_SECURITY_PROTOCOL_MAP" = "INTERNAL:SASL_PLAINTEXT" ]]; then
+        LISTENER_SECURITY_PROTOCOL_MAP="${LISTENER_SECURITY_PROTOCOL_MAP},CLIENT:SASL_PLAINTEXT"
       else
         LISTENER_SECURITY_PROTOCOL_MAP="${LISTENER_SECURITY_PROTOCOL_MAP},CLIENT:PLAINTEXT"
       fi

--- a/operator/templates/krb5-config.yaml
+++ b/operator/templates/krb5-config.yaml
@@ -13,5 +13,7 @@ data:
 
     [realms]
     {{ .Params.KERBEROS_REALM }} = {
+    {{ if .Params.KERBEROS_KDC_HOSTNAME }}
     kdc = {{ .Params.KERBEROS_KDC_HOSTNAME }}:{{ .Params.KERBEROS_KDC_PORT }}
+    {{ end }}
     }


### PR DESCRIPTION
I ran into a handful of bugs/issues when attempting to install KUDO Kafka with Kerberos enabled. This PR attempts to resolve these issues. Brief summary:

* Updated the bootstrap template to simply copy the keytab file to KAFKA_HOME from the mount directory; by default, file-based Secrets (i.e. Opaque Secrets using the  `data` field) are already converted from base64 --> binary when added into a Pod, so having an extra `base64 --decode` results in an error.
* Updated the bootstrap template the set the CLIENT listener to use SASL_PLAINTEXT if the INTERNAL listener is using SASL_PLAINTEXT; previously, the CLIENT listener was only set to use SASL_PLAINTEXT if SCRAM was being utilized, which caused issues when attempting to authenticate with a Kafka Client when Kerberos was enabled
* Updated the krb5-config template to make KERBEROS_KDC_HOSTNAME optional; some organizations have self-discovery for the KDC, which means  `{{ .Params.KERBEROS_REALM }} = {}` is a valid configuration in some cases
* Updated the Security docs to fix an error in the naming convention for the Kerberos principals, and make the keytab creation step a bit more clear

I was not able to run the tests available in this repo, as I do not have access to the submodules, but I have a running deployment with these changes at my organization that is functioning as expected (Kerberos authentication is enabled and functioning properly for the brokers and clients).

If you need anything else from me, please let me know. 